### PR TITLE
Fix duplicate and nested functions

### DIFF
--- a/database.py
+++ b/database.py
@@ -251,11 +251,6 @@ def add_admin_column():
     except sqlite3.OperationalError as e:
         print(f"Помилка: {e}")
 
-def get_user_id_by_ticket(ticket_id):
-    cursor.execute('SELECT user_id FROM tickets WHERE ticket_id = ?', (ticket_id,))
-    result = cursor.fetchone()
-    print(f"Отримано user_id для тікета {ticket_id}: {result}")  # Додаємо логування
-    return result[0] if result else None
 
 
 def check_connection():

--- a/handlers.py
+++ b/handlers.py
@@ -568,37 +568,20 @@ async def cmd_close_ticket(message: types.Message):
             cursor.execute('UPDATE tickets SET status = ? WHERE ticket_id = ?', ('closed', ticket_id))
             conn.commit()
 
-            async def cmd_close_ticket(message: types.Message):
-                user_language = get_user_language(message.from_user.id)  # Отримуємо мову користувача
-                parts = message.text.split(maxsplit=1)  # /close <ticket_id>
-
-                if len(parts) == 2:
-                    try:
-                        ticket_id = int(parts[1])
-                        # Оновлюємо статус тікета на "closed"
-                        cursor.execute('UPDATE tickets SET status = ? WHERE ticket_id = ?', ('closed', ticket_id))
-                        conn.commit()
-
-                        if user_language == 'uk':
-                            await message.answer(f"Тікет #{ticket_id} успішно закрито.")
-                        else:
-                            await message.answer(f"Тикет #{ticket_id} успешно закрыт.")
-                    except ValueError:
-                        if user_language == 'uk':
-                            await message.answer("Неправильний формат. Використовуйте: /close <ticket_id>")
-                        else:
-                            await message.answer("Неправильный формат. Используйте: /close <ticket_id>")
-                else:
-                    if user_language == 'uk':
-                        await message.answer("Неправильний формат. Використовуйте: /close <ticket_id>")
-                    else:
-                        await message.answer("Неправильный формат. Используйте: /close <ticket_id>")
-
-            await message.answer(f"Тікет #{ticket_id} успішно закрито.")
+            if user_language == 'uk':
+                await message.answer(f"Тікет #{ticket_id} успішно закрито.")
+            else:
+                await message.answer(f"Тикет #{ticket_id} успешно закрыт.")
         except ValueError:
-            await message.answer("Неправильний формат. Використовуйте: /close <ticket_id>")
+            if user_language == 'uk':
+                await message.answer("Неправильний формат. Використовуйте: /close <ticket_id>")
+            else:
+                await message.answer("Неправильный формат. Используйте: /close <ticket_id>")
     else:
-        await message.answer("Неправильний формат. Використовуйте: /close <ticket_id>")
+        if user_language == 'uk':
+            await message.answer("Неправильний формат. Використовуйте: /close <ticket_id>")
+        else:
+            await message.answer("Неправильный формат. Используйте: /close <ticket_id>")
 
 # Обробник для закриття тікета через callback-кнопку (для користувача)
 


### PR DESCRIPTION
## Summary
- remove redundant `get_user_id_by_ticket` from database module
- clean up `/close` command handler to avoid nested function

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fd209f978832598f9cf2be5da3a9b